### PR TITLE
Extended CAN IDs for FromCanUtilsLog

### DIFF
--- a/Pipeline/FromCanUtilsLog.py
+++ b/Pipeline/FromCanUtilsLog.py
@@ -1,12 +1,10 @@
 import re
 
-
 def canUtilsToTSV(filename):
     outFileName = filename + ".tsv"
     with open(outFileName, "w") as outFile:
         with open(filename, "r") as file:
-            linePattern = re.compile(
-                r"\((\d+.\d+)\)\s+[^\s]+\s+(.{3})#([0-9A-F]+)")
+            linePattern = re.compile(r"\((\d+.\d+)\)\s+[^\s]+\s+(.{3}|.{8})#([0-9A-F]+)")
 
             while True:
                 line = file.readline()

--- a/Pipeline/Plotter.py
+++ b/Pipeline/Plotter.py
@@ -1,6 +1,6 @@
 import matplotlib.pyplot as plt
 from matplotlib.pyplot import savefig
-from numpy import where, isin
+from numpy import where, isin, ndarray
 from os import chdir, mkdir, path
 from shutil import rmtree
 from PipelineTimer import PipelineTimer
@@ -39,6 +39,10 @@ def plot_signals_by_arb_id(a_timer: PipelineTimer, arb_id_dict: dict, signal_dic
                     signals_to_plot.append(signal)
             # One row per signal plus one for the TANG
             fig, axes = plt.subplots(nrows=1 + len(signals_to_plot), ncols=1)
+            if not isinstance(axes, ndarray):
+                print("Static signal. No figures to plot")
+                continue
+
             plt.suptitle("Time Series and TANG for Arbitration ID " + hex(k_id),
                          weight='bold',
                          position=(0.5, 1))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+scikit-learn
+pandas
+matplotlib


### PR DESCRIPTION
Added support for extended CAN IDs in `FromCanUtilsLog`. 

I also had problems with the plotter when there were static signals. I wasn't quite sure, but according to a commend in the sourcecode, you don't want to plot static signals. So I added a check to skip those signals.

Finally, I added a small `requirements.txt` which is a good help to install necessary python dependencies.
